### PR TITLE
Add GitHub Actions workflow for automatic PR updates from upstream re…

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,16 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@master
+    with:
+      upstream_repository: https://github.com/CrunchyData/postgres-operator-examples
+      upstream_branch: 'main'
+    secrets:
+      personal_access_token: ${{ secrets.GH_AUTO_PR }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of pull requests from an upstream repository. The workflow is scheduled to run daily at noon and can also be triggered manually.

Automated pull request workflow:

* [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1R1-R16): Added a new workflow named "Upstream to PR" that uses the `neuro-inc/reuse` action to create pull requests from the `CrunchyData/postgres-operator-examples` repository's main branch. The workflow is scheduled to run daily at 12:00 PM and can also be triggered manually.