### PR TITLE
Fix SQL syntax for granting permissions by adding quotes around user …

### DIFF
--- a/helm/postgres/templates/_init_sql.tpl
+++ b/helm/postgres/templates/_init_sql.tpl
@@ -17,9 +17,9 @@
 \c {{ $db }};
 CREATE EXTENSION IF NOT EXISTS vector SCHEMA public;
 {{- range $users }}
-GRANT USAGE, CREATE ON SCHEMA public TO {{ . }};
+GRANT USAGE, CREATE ON SCHEMA public TO "{{ . }}";
 CREATE SCHEMA IF NOT EXISTS {{ . }};
-GRANT ALL ON SCHEMA {{ . }} TO {{ . }};
+GRANT ALL ON SCHEMA {{ . }} TO "{{ . }}";
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Fix Init Script by adding double quotes around user name.

These are the logs from Postgres Operator showing syntax error:

<img width="684" height="312" alt="image" src="https://github.com/user-attachments/assets/e3a6e6a0-51fd-4c7c-8abb-7d4b3bf3cdc9" />

These are tests that I ran manually with `psql` cli:

<img width="643" height="196" alt="image" src="https://github.com/user-attachments/assets/661d119e-a4ef-49d2-900d-bb6dbd3e20ac" />
