### PR TITLE
IT-94: do not provision a backup repo when backups are disabled [blocked on IT-145 CRD update]

### DIFF
--- a/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
+++ b/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
@@ -1,0 +1,103 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+CHART_PATH = Path(__file__).parents[4] / "helm" / "postgres"
+AUTHORIZE_REMOVAL_ANNOTATION = (
+    "postgres-operator.crunchydata.com/authorizeBackupRemoval"
+)
+
+BASE_VALUES = {
+    "name": "pg-testapp",
+    "postgresVersion": "16",
+    "instances": [
+        {
+            "name": "instance1",
+            "replicas": 2,
+            "dataVolumeClaimSpec": {
+                "accessModes": ["ReadWriteOnce"],
+                "resources": {"requests": {"storage": "10Gi"}},
+            },
+        }
+    ],
+    "users": [{"name": "postgres"}],
+}
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None, reason="helm is required to render the chart"
+)
+
+
+def render_postgrescluster(tmp_path, **overrides):
+    values = {**BASE_VALUES, **overrides}
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text(yaml.safe_dump(values))
+
+    output = subprocess.run(
+        ["helm", "template", "pg", str(CHART_PATH), "-f", str(values_file)],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+
+    for doc in yaml.safe_load_all(output):
+        if doc and doc.get("kind") == "PostgresCluster":
+            return doc
+    pytest.fail("chart did not render a PostgresCluster")
+    return None
+
+
+def test_no_backup_repo_when_backups_are_not_configured(tmp_path):
+    """Installing without backups must not provision a pgBackRest repo.
+
+    Regression test for IT-94: the chart used to fall back to a 1Gi volume repo,
+    so an app installed with backups off still got a PVC that later filled up.
+    """
+    cluster = render_postgrescluster(tmp_path)
+
+    assert "backups" not in cluster["spec"]
+
+
+def test_backup_removal_is_authorized_when_backups_are_not_configured(tmp_path):
+    """Existing clusters need this annotation to drop a repo they already have.
+
+    Without it the operator pauses reconciliation instead of removing the repo.
+    """
+    cluster = render_postgrescluster(tmp_path)
+
+    annotations = cluster["metadata"]["annotations"]
+    assert annotations[AUTHORIZE_REMOVAL_ANNOTATION] == "true"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"backupsSize": "5Gi"}, id="volume"),
+        pytest.param(
+            {"s3": {"bucket": "bkt", "endpoint": "s3.amazonaws.com", "region": "us"}},
+            id="s3",
+        ),
+        pytest.param({"gcs": {"bucket": "bkt", "key": "{}"}}, id="gcs"),
+        pytest.param({"azure": {"container": "cnt"}}, id="azure"),
+    ],
+)
+def test_configured_backups_are_kept_and_not_authorized_for_removal(
+    tmp_path, overrides
+):
+    cluster = render_postgrescluster(tmp_path, **overrides)
+
+    assert cluster["spec"]["backups"]["pgbackrest"]["repos"]
+    assert AUTHORIZE_REMOVAL_ANNOTATION not in cluster["metadata"]["annotations"]
+
+
+def test_configured_backup_volume_uses_the_requested_size(tmp_path):
+    cluster = render_postgrescluster(tmp_path, backupsSize="5Gi")
+
+    repo = cluster["spec"]["backups"]["pgbackrest"]["repos"][0]
+    assert (
+        repo["volume"]["volumeClaimSpec"]["resources"]["requests"]["storage"] == "5Gi"
+    )

--- a/helm/postgres/templates/_backups.tpl
+++ b/helm/postgres/templates/_backups.tpl
@@ -1,0 +1,6 @@
+{{/* Whether any pgBackRest repository is configured. Empty output means backups are off */}}
+{{- define "postgres.backupsConfigured" }}
+{{- if or .Values.pgBackRestConfig .Values.multiBackupRepos .Values.s3 .Values.gcs .Values.azure .Values.backupsSize }}
+true
+{{- end }}
+{{- end }}

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ default .Release.Name .Values.name }}
   annotations:
     postgres-operator.crunchydata.com/autoCreateUserSchema: "true"
+    {{- if not (include "postgres.backupsConfigured" .) }}
+    {{/* Without this the operator pauses reconciliation of clusters that used to have a repo */}}
+    postgres-operator.crunchydata.com/authorizeBackupRemoval: "true"
+    {{- end }}
 spec:
   postgresVersion: {{ required "You must set the version of Postgres to deploy." .Values.postgresVersion }}
   {{- if .Values.postGISVersion }}
@@ -38,6 +42,7 @@ spec:
           memory: {{ default "" .Values.instanceMemory | quote }}
       {{- end }}
   {{- end }}
+  {{- if include "postgres.backupsConfigured" . }}
   backups:
     pgbackrest:
       {{- if .Values.imagePgBackRest }}
@@ -132,6 +137,7 @@ spec:
               requests:
                 storage: {{ default "1Gi" .Values.backupsSize | quote }}
       {{- end }}
+  {{- end }}
   {{- if or .Values.pgBouncerReplicas .Values.pgBouncerConfig }}
   proxy:
     pgBouncer:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     postgres-operator.crunchydata.com/autoCreateUserSchema: "true"
     {{- if not (include "postgres.backupsConfigured" .) }}
-    {{/* Without this the operator pauses reconciliation of clusters that used to have a repo */}}
+    {{- /* Without this the operator pauses reconciliation of clusters that used to have a repo */}}
     postgres-operator.crunchydata.com/authorizeBackupRemoval: "true"
     {{- end }}
 spec:


### PR DESCRIPTION
## Problem

Installing the PostgreSQL app **without** backups still created a `<name>-repo1` PVC of **1Gi** plus a `-repo-host` StatefulSet. Backup jobs wrote into it and filled it up ([IT-94](https://apolocloud.atlassian.net/browse/IT-94)).

`helm/postgres/templates/postgres.yaml` ended its backups chain in an unconditional `{{- else }}` that emitted a volume repo, and `inputs_processor.py:227` returns `{}` when `backup is None` — so nothing suppressed it. The app only ever backs up to a bucket (`_build_provider_values` emits s3/gcs), so that volume repo existed purely as this fallback.

## Change

- Guard the whole `backups:` block behind a shared `postgres.backupsConfigured` helper and omit it when no repository is configured.
- Emit `postgres-operator.crunchydata.com/authorizeBackupRemoval: "true"` when — and only when — backups are off.

The annotation is not cosmetic. Removing a repo is a **two-key operation** in PGO: dropping `spec.backups` while a `-repo-host` StatefulSet still exists pauses reconciliation, and the PVC survives, so without it every already-installed app would freeze on upgrade:

```
Progressing | status=False | reason=Paused
  message: Reconciliation is paused: please fill in spec.backups or add the
           postgres-operator.crunchydata.com/authorizeBackupRemoval annotation
           to authorize backup removal.
```

## No operator upgrade needed

`spec.backups` stopped being required in the CRD at PGO **5.7.0**, and **5.8.3** is already deployed on dev (`cloud-infra/control-plane-apps/apps_postgres_operator.tf:5`) and on compute (`platform-operator/charts/platform/values.yaml:161`). This closes [IT-145](https://apolocloud.atlassian.net/browse/IT-145).

## Verification

Ran against the **real PGO 5.8.3** (`postgres-operator:ubi9-5.8.3-0`) in a throwaway kind cluster, using this branch's chart:

| Scenario | Result |
|---|---|
| Install the **pre-change** chart, backups off | `repo1` PVC **1Gi** + repo-host STS — bug reproduced |
| **Upgrade** that legacy cluster to this branch | repo-host + repo1 PVC removed, **no** Paused condition, instances 1/1 Ready, `SELECT` works |
| Same upgrade **without** the annotation | `Paused`, PVC still attached — confirms the annotation is required |
| Fresh install, backups off | only the 10Gi pgdata PVCs; zero repo objects |
| `backupsSize: 5Gi` | repo1 at 5Gi, repo-host present, **no** removal annotation |

Added `test_postgres_chart_backups.py`, which renders the chart and covers all of the above (skipped when `helm` is absent). Full unit suite, `mypy` and `pre-commit` pass.

## Behaviour notes

- With backups off, `archive_mode` stays `on` and `archive_command` becomes `true` — WAL is discarded, **no Postgres restart**. PITR is lost; HA/streaming replication is unaffected.
- Clone/restore is unaffected: `source` renders `spec.dataSource.pgbackrest`, which the operator handles as `cloudDataSource` and does not gate on `backupsSpecFound`.

## Still to verify before release

- Bucket-backed backups end-to-end on dev (covered here only by render equivalence + a live volume-repo test).
- That bucket **contents** survive when a user turns off previously-enabled bucket backups.

[IT-94]: https://apolocloud.atlassian.net/browse/IT-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IT-145]: https://apolocloud.atlassian.net/browse/IT-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ