### PR TITLE
IT-145: offer PostgreSQL 17

### DIFF
--- a/.apolo/src/apolo_apps_postgresql/schemas/PostgresInputs.json
+++ b/.apolo/src/apolo_apps_postgresql/schemas/PostgresInputs.json
@@ -389,7 +389,8 @@
         "13",
         "14",
         "15",
-        "16"
+        "16",
+        "17"
       ],
       "title": "PostgresSupportedVersions",
       "type": "string"

--- a/.apolo/src/apolo_apps_postgresql/types.py
+++ b/.apolo/src/apolo_apps_postgresql/types.py
@@ -37,6 +37,7 @@ class PostgresSupportedVersions(enum.StrEnum):
     v14 = "14"
     v15 = "15"
     v16 = "16"
+    v17 = "17"
 
 
 POSTGRES_RESOURCES_PATTERN = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"


### PR DESCRIPTION
## What

Adds `17` to `PostgresSupportedVersions`. Schemas regenerated by the pre-commit hook, not hand-edited.

## Why

The operator has shipped Postgres 17 images since 5.8.x — we simply never offered them. From `helm/install/values.yaml` (PGO 5.8.3, the version deployed on dev and on both compute clusters):

```
postgres_17          crunchy-postgres:ubi9-17.6-2534
postgres_17_gis_3.5  crunchy-postgres-gis:ubi9-17.6-3.5-2534
postgres_17_gis_3.4  crunchy-postgres-gis:ubi9-17.6-3.4-2534
```

So this needs **no operator upgrade** — it was purely our own enum capping at 16.

## Separate finding, not fixed here: versions 12–15 cannot work

The same `relatedImages` block ships images for **only 16 and 17**. The enum still offers `12`, `13`, `14`, `15`, for which no image exists. The operator resolves the image from `RELATED_IMAGE_POSTGRES_<version>` and returns an **empty string** when it is unset — confirmed by its own test (`internal/config/config_test.go`):

```go
cluster.Spec.PostgresVersion = 12
os.Unsetenv("RELATED_IMAGE_POSTGRES_12")
assert.Equal(t, PostgresContainerImage(cluster), "")
```

So picking 12–15 today produces a cluster with no image. I have deliberately **not** removed them in this PR: dropping enum values could break `apolo app configure` for any existing instance that stored one, and I cannot survey the compute clusters (no kubectl context). The only cluster on dev is on 16. Worth deciding separately — happy to follow up once we know whether any instance is on <16.

## Verification

Unit suite (35) and `mypy` pass. Schema diff is the single expected line:

```diff
         "15",
-        "16"
+        "16",
+        "17"
```

e2e on dev to follow — a branch install needs this PR to exist first, since CI only builds the hook image on `pull_request`/push to `apolo`, and without that image the preprocessor pod just hangs to its deadline.