### PR TITLE
IT-163: stop forcing WAL segment switches when backups are disabled

### DIFF
--- a/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
+++ b/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
@@ -153,3 +153,40 @@ def test_other_patroni_parameters_are_preserved(tmp_path):
     parameters = patroni_parameters(cluster)
     assert parameters["max_connections"] == 200
     assert parameters["archive_timeout"] == 0
+
+
+def test_empty_parameters_block_still_gets_the_setting(tmp_path):
+    """A key written with nothing under it parses as None, not as an empty map.
+
+    Found in review: merging the default under that None dropped the setting
+    silently and rendered `parameters: null` into the cluster spec.
+    """
+    overrides = {
+        "patroni": {"dynamicConfiguration": {"postgresql": {"parameters": None}}}
+    }
+    cluster = render_postgrescluster(tmp_path, **overrides)
+
+    assert patroni_parameters(cluster)["archive_timeout"] == 0
+
+
+def test_empty_patroni_block_still_gets_the_setting(tmp_path):
+    cluster = render_postgrescluster(tmp_path, patroni={})
+
+    assert patroni_parameters(cluster)["archive_timeout"] == 0
+
+
+def test_unrelated_patroni_keys_survive(tmp_path):
+    overrides = {
+        "patroni": {
+            "dynamicConfiguration": {
+                "synchronous_mode": True,
+                "postgresql": {"pg_hba": ["host all all 0.0.0.0/0 md5"]},
+            }
+        }
+    }
+    cluster = render_postgrescluster(tmp_path, **overrides)
+
+    dynamic = cluster["spec"]["patroni"]["dynamicConfiguration"]
+    assert dynamic["synchronous_mode"] is True
+    assert dynamic["postgresql"]["pg_hba"] == ["host all all 0.0.0.0/0 md5"]
+    assert dynamic["postgresql"]["parameters"]["archive_timeout"] == 0

--- a/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
+++ b/.apolo/tests/unit/postgres/test_postgres_chart_backups.py
@@ -101,3 +101,55 @@ def test_configured_backup_volume_uses_the_requested_size(tmp_path):
     assert (
         repo["volume"]["volumeClaimSpec"]["resources"]["requests"]["storage"] == "5Gi"
     )
+
+
+def patroni_parameters(cluster):
+    patroni = cluster["spec"].get("patroni") or {}
+    dynamic = patroni.get("dynamicConfiguration") or {}
+    return (dynamic.get("postgresql") or {}).get("parameters") or {}
+
+
+def test_wal_archiving_is_not_forced_when_backups_are_not_configured(tmp_path):
+    """The operator sets archive_timeout=60 and archive_command=true.
+
+    With no repo to archive to, that switches a full 16MB WAL segment every
+    minute on any cluster taking writes and throws it away. Measured on dev
+    under IT-163: one segment per minute, stopping the moment this is set.
+    """
+    cluster = render_postgrescluster(tmp_path)
+
+    assert patroni_parameters(cluster)["archive_timeout"] == 0
+
+
+def test_configured_backups_leave_archiving_alone(tmp_path):
+    cluster = render_postgrescluster(tmp_path, backupsSize="5Gi")
+
+    assert "archive_timeout" not in patroni_parameters(cluster)
+
+
+def test_explicit_archive_timeout_wins(tmp_path):
+    overrides = {
+        "patroni": {
+            "dynamicConfiguration": {
+                "postgresql": {"parameters": {"archive_timeout": 300}}
+            }
+        }
+    }
+    cluster = render_postgrescluster(tmp_path, **overrides)
+
+    assert patroni_parameters(cluster)["archive_timeout"] == 300
+
+
+def test_other_patroni_parameters_are_preserved(tmp_path):
+    overrides = {
+        "patroni": {
+            "dynamicConfiguration": {
+                "postgresql": {"parameters": {"max_connections": 200}}
+            }
+        }
+    }
+    cluster = render_postgrescluster(tmp_path, **overrides)
+
+    parameters = patroni_parameters(cluster)
+    assert parameters["max_connections"] == 200
+    assert parameters["archive_timeout"] == 0

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -150,9 +150,14 @@ spec:
       replicas: {{ .Values.pgBouncerReplicas }}
       {{- end }}
   {{- end }}
-  {{- if .Values.patroni }}
+  {{- $patroni := .Values.patroni | default dict }}
+  {{- if not (include "postgres.backupsConfigured" .) }}
+  {{- $noArchive := dict "dynamicConfiguration" (dict "postgresql" (dict "parameters" (dict "archive_timeout" 0))) }}
+  {{- $patroni = mergeOverwrite $noArchive (deepCopy $patroni) }}
+  {{- end }}
+  {{- if $patroni }}
   patroni:
-{{ toYaml .Values.patroni | indent 4 }}
+{{ toYaml $patroni | indent 4 }}
   {{- end }}
   {{- if .Values.users }}
   users:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -150,10 +150,17 @@ spec:
       replicas: {{ .Values.pgBouncerReplicas }}
       {{- end }}
   {{- end }}
-  {{- $patroni := .Values.patroni | default dict }}
+  {{- $patroni := deepCopy (.Values.patroni | default dict) }}
   {{- if not (include "postgres.backupsConfigured" .) }}
-  {{- $noArchive := dict "dynamicConfiguration" (dict "postgresql" (dict "parameters" (dict "archive_timeout" 0))) }}
-  {{- $patroni = mergeOverwrite $noArchive (deepCopy $patroni) }}
+  {{- $dynamic := get $patroni "dynamicConfiguration" | default dict }}
+  {{- $postgresql := get $dynamic "postgresql" | default dict }}
+  {{- $parameters := get $postgresql "parameters" | default dict }}
+  {{- if not (hasKey $parameters "archive_timeout") }}
+  {{- $_ := set $parameters "archive_timeout" 0 }}
+  {{- end }}
+  {{- $_ := set $postgresql "parameters" $parameters }}
+  {{- $_ := set $dynamic "postgresql" $postgresql }}
+  {{- $_ := set $patroni "dynamicConfiguration" $dynamic }}
   {{- end }}
   {{- if $patroni }}
   patroni:


### PR DESCRIPTION
Closes IT-163.

### What the ticket asked, and what is actually true

"Make sure WAL archiving is disabled when backups are disabled." Measured on dev against a cluster rendered from this chart with no backup config, the operator sets:

```
archive_mode    = on
archive_command = true          <- /bin/true, a no-op
archive_timeout = 60
```

So archiving is *neutralised* rather than disabled — every segment is instantly considered archived and nothing piles up. The worry about a WAL backlog does not materialise, and I checked: over 5 minutes on an idle cluster `pg_wal` stayed at exactly one 16MB segment.

**But `archive_timeout=60` costs real writes.** It forces a switch of a partially-filled segment every minute, and a switched segment is a whole 16MB. With one 200-byte `INSERT` every 10 seconds:

| | segment | pg_wal files |
|---|---|---|
| `archive_timeout=60` | advances every ~60s | 4 → 5 → 6 |
| `archive_timeout=0` | unchanged over 3 min | steady |

That is ~16MB/min — roughly 23GB/day — of writes discarded to `/bin/true`, for a database receiving a few hundred bytes per minute. `pg_wal` itself does plateau (`min_wal_size=80MB`, `max_wal_size=1GiB`), so this is about pointless disk I/O rather than about running out of space.

### The change

Set `archive_timeout: 0` via `patroni.dynamicConfiguration` when, and only when, no repo is configured — reusing the existing `postgres.backupsConfigured` helper from IT-94.

**Why not `archive_mode: off`, which is what "disable archiving" would literally mean:** `archive_mode` is a `postmaster`-context parameter, so changing it needs a full database restart. Leaving it on is what lets a user turn backups on later without one. `archive_timeout` is `sighup`; applying this to the live cluster took effect with **zero restarts** (`RESTARTS 0`, pod age unchanged).

### Verification

Not just rendered — applied. Sequence on dev, one cluster throughout:

1. Deployed from this chart, no backups → `archive_timeout=60`, segment churning every minute.
2. Applied this chart's output → `archive_timeout=0`, churn stopped, pod not restarted.
3. **Removed the setting again → back to `60`.** Done deliberately: without that step "still 0" would not prove the chart did anything.

Locally: 39 unit tests, `mypy`, `helm lint`, and `pre-commit` in CI mode all pass. Four new tests cover backups-off, backups-on, an explicit user value winning, and unrelated `patroni` parameters surviving the merge.

### Two things found on the way, not fixed here

* **IT-94 and IT-145 are unreleased.** The last tag is `v26.5.0`; `_backups.tpl` and the whole "no repo when backups are off" behaviour exist only on `apolo`, 9 commits ahead. The `postgres` app template points at `v26.5.0`, so today every installed postgres app still gets a backup repo and this ticket's condition cannot even be reached in production. **This PR needs a release to have any effect** — worth cutting one that carries IT-94, IT-145 and this together.
* Because of the above, the app I installed on dev to test came up *with* `spec.backups`; the measurements here were taken against a cluster rendered directly from the branch.
